### PR TITLE
Remove 1.8.7 from travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
 script: bundle exec rake test


### PR DESCRIPTION
Since new HTTParty dependency can't be resolved for Ruby < 1.9.3 (deprecated versions).
